### PR TITLE
change EDL file to reflect type of parameters

### DIFF
--- a/passwordManager/passwordManagerEnclave/passwordManagerEnclave/passwordManagerEnclave.edl
+++ b/passwordManager/passwordManagerEnclave/passwordManagerEnclave/passwordManagerEnclave.edl
@@ -5,20 +5,20 @@ enclave {
 
     trusted {
         /* define ECALLs here. */
-		public int addUser([in, size=len] char *username, [in, size=len] char *password, size_t len);
-		public int authenticate([in,size=len] char *username, [in,size=len] char *password, size_t len);
-		public int findUser([in, size=len] char* username, size_t len);
-		public int getAccount([in, out, size=len] char *username, size_t len);
-		public int getPassword([in, out, size=len] char *username, size_t len);
-		public int getUrl([in, out, size=len] char *username, size_t len);
-		public int removeUser([in, size=len] char *username, size_t len);
+		public int addUser([in, string] char *username, [in, string] char *password, size_t len);
+		public int authenticate([in, string] char *username, [in, string] char *password, size_t len);
+		public int findUser([in, string] char* username, size_t len);
+		public int getAccount([in, out, string] char *username, size_t len);
+		public int getPassword([in, out, string] char *username, size_t len);
+		public int getUrl([in, out, string] char *username, size_t len);
+		public int removeUser([in, string] char *username, size_t len);
 	
 	//NOTE: since the code is written under the assumption that there will be a GUI 
 	// wrapper, setter functions assume user is authenticated
 		
-		public int setAccount([in, size=len] char *username, [in, size=len] char *data, size_t len);
-		public int setPassword([in, size=len] char *username, [in, size=len] char *data, size_t len);
-		public int setUrl([in, size=len] char *username, [in, size=len] char *data, size_t len);
+		public int setAccount([in, string] char *username, [in, string] char *data, size_t len);
+		public int setPassword([in, string] char *username, [in, string] char *data, size_t len);
+		public int setUrl([in, string] char *username, [in, string] char *data, size_t len);
 
     };
 


### PR DESCRIPTION
username, password and data are all strings. They are not binary blobs. Need to annotate them with string, else there is no 0-byte termination guarantee, which can lead to all sorts of badness.
